### PR TITLE
Send SIGINT instead of SIGTERM to terminate child processes

### DIFF
--- a/juniper-vpn.py
+++ b/juniper-vpn.py
@@ -223,7 +223,11 @@ class juniper_vpn(object):
             self.r = self.br.open(self.r.geturl())
 
 def cleanup():
-    os.killpg(0, signal.SIGTERM)
+    # Use SIGINT due to openconnect behavior where SIGINT will
+    # run the vpnc-compatible script to clean up changes but
+    # not upon SIGTERM.
+    # http://permalink.gmane.org/gmane.network.vpn.openconnect.devel/2451
+    os.killpg(0, signal.SIGINT)
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(conflict_handler='resolve')


### PR DESCRIPTION
When calling openconnect (the typical use case for this script)
it only properly cleans up the connection when sent SIGINT,
not SIGTERM.

This could be made a configurable option, but I wasn't convinced that made any sense. See the discussion at http://permalink.gmane.org/gmane.network.vpn.openconnect.devel/2451 which discusses this behavior in openconnect.
