### PR TITLE
A few fixes that helped out in my environment

### DIFF
--- a/tncc.py
+++ b/tncc.py
@@ -11,7 +11,8 @@ import collections
 import zlib
 import HTMLParser
 
-ssl._create_default_https_context = ssl._create_unverified_context
+if hasattr(ssl, '_create_unverified_context'):
+    ssl._create_default_https_context = ssl._create_unverified_context
 
 # 0013 - Message
 def decode_0013(buf):


### PR DESCRIPTION
- Allow a specific landing page URL to be used instead of a host name.
- Press "Proceed" button if there's a warning message splash prior to the login page
- Fix for `ssl._create_unverified_context` undefined error on slightly older Python installations.
