### PR TITLE
Adds support for two factor authentication with password composed of fixed prefix and variable postfix

### DIFF
--- a/README
+++ b/README
@@ -5,7 +5,7 @@ cookie (DSID), and then passes that cookie to a VPN client.
 
 Example usage with openconnect:
 
-./juniper-vpn.py --host vpn.example.com --user joeuser --stdin DSID=%DSID% \
+./juniper-vpn.py --host vpn.example.com --username joeuser --stdin DSID=%DSID% \
 	openconnect --juniper %HOST% --cookie-on-stdin
 
 This will connect to vpn.example.com and prompt the user for a authentication
@@ -31,6 +31,10 @@ juniper-vpn.py [-h HOST] [-u USERNAME] [-o OATH] [-c CONFIG] [-s STDIN] \
 
 -u --username
 	Username to authenticate with. This option is required.
+
+-p --pass_prefix
+    Optional, used for passwords composed of fixed prefix and variable postfix.
+    This is fixed prefix part.
 
 -o --oath
 	OATH key to use for OTP generation if required for authentication.

--- a/sample.cfg
+++ b/sample.cfg
@@ -6,6 +6,6 @@ password = nobodyknows
 oath = d41d8cd98f00b204e9800998ecf8427e
 
 stdin = DSID=%DSID%
-action = openconnect --juniper %HOST% --cookie-on-stdin --script-tun
-	--script "tunproxy -D 8080"
+action = openconnect --juniper %HOST% --pass_prefix=1234 --cookie-on-stdin --script-tun
+       --script "tunproxy -D 8080"
 


### PR DESCRIPTION
This patch adds support for secondary password composed of fixed prefix and variable postfix is required. Usually variable postfix of such password is sent via SMS, then user has to enter concatenation of invariable secret prefix known only to him and postfix received.

Please integrate if you're interested
