### PR TITLE
Handle preauth and postauth popups

### DIFF
--- a/juniper-vpn.py
+++ b/juniper-vpn.py
@@ -146,7 +146,15 @@ class juniper_vpn(object):
 
         for form in self.br.forms():
             if form.name == 'frmLogin':
-                return 'login'
+                try:
+                    form.find_control('sn-preauth-proceed')
+                    return 'continue'
+                except mechanize.ControlNotFoundError:
+                    try:
+                        form.find_control('sn-postauth-proceed')
+                        return 'continue'
+                    except mechanize.ControlNotFoundError:
+                        return 'login'
             elif form.name == 'frmDefender':
                 return 'key'
             elif form.name == 'frmConfirmation':


### PR DESCRIPTION
I'm using Junos Pulse VPN to access corporate network. The server configured to confirmation forms (agree with corporate terms of use...) before and after login page. Current version of juniper-vpn-py doesn't handle it. I found code that handle only preauth confirmation (https://github.com/dobesv/juniper-vpn-py/commit/082ac84d7a08dd45155b69c54005980bf6cd363d#diff-0d6d2b6717d65654e57f97bd51baa35aR118) but it is partial solution in my case. I've added almost the same solution for postauth confirmation.
