### PR TITLE
force python2, add basic matrixcard support

### DIFF
--- a/juniper-vpn.py
+++ b/juniper-vpn.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 # -*- coding: utf-8 -*-
 
 import subprocess
@@ -22,10 +22,10 @@ import platform
 import socket
 import netifaces
 import datetime
+import re
 
 debug = False
 
-ssl._create_default_https_context = ssl._create_unverified_context
 
 """
 OATH code from https://github.com/bdauvergne/python-oath
@@ -134,6 +134,9 @@ class juniper_vpn(object):
         self.key = None
         self.pass_postfix = None
 
+    def get_matrix_index(self, html):
+        return re.search(r'Challenge: (\w+)', html).group(1)
+
     def find_cookie(self, name):
         for cookie in self.cj:
             if cookie.name == name:
@@ -234,7 +237,8 @@ class juniper_vpn(object):
                 sys.exit(1)
             self.key = hotp(self.args.oath)
         elif self.key is None:
-            self.key = getpass.getpass('Two-factor key:')
+            matrix = self.get_matrix_index(self.br.response().read())
+            self.key = getpass.getpass('Two-factor key (' + matrix + '):')
         self.br.select_form(nr=0)
         self.br.form['password'] = self.key
         self.key = None

--- a/tncc.py
+++ b/tncc.py
@@ -26,7 +26,6 @@ import pyasn1_modules.rfc2459
 import pyasn1.codec.der.decoder
 import xml.etree.ElementTree
 
-ssl._create_default_https_context = ssl._create_unverified_context
 
 debug = False
 logging.basicConfig(stream=sys.stderr, level=logging.DEBUG if debug else logging.INFO)


### PR DESCRIPTION
Main reason for this pull request is extended 2-Factor support. My organization uses matrixcards for auth. Server gives me an index and I have to enter the key. This patch enables parsing the webform and shows the matrixcard index on CLI. No error checking yet, nothing. Works for me, but dont know about any other setups out there. Happy to improve if needed for getting this upstream.
Furthermore:

some ssl-context stuff i dont understand from:
https://github.com/dnschneid/crouton/wiki/Juniper-Junos-Pulse-VPN-with-OpenConnect

python2 in shebang, cus script fails when running on a python3 default system.
